### PR TITLE
Add extra line break to model blocks to ensure correct PDF wrapping behaviour

### DIFF
--- a/R/blocks.R
+++ b/R/blocks.R
@@ -57,7 +57,7 @@ sbr_blocks <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
   data$caption <- p0("Block ", 1:nrow(data), ". ", data$caption)
   data$caption <- add_full_stop(data$caption)
   
-  data$blocks <- p0("```\n.", data$blocks, "\n..\n```")
+  data$blocks <- p0("```\n.\n", data$blocks, "\n..\n```")
   
   txt <- character(0)
   for (i in seq_len(nrow(data))) {

--- a/tests/testthat/results.Rmd
+++ b/tests/testthat/results.Rmd
@@ -1,12 +1,12 @@
 ---
 title: 'testthat'
-date: 2021-11-30 16:24:12
+date: 2024-10-25 14:48:25.85988
 ---
 
 ```{r, echo = FALSE, warning = FALSE, message = FALSE, include = FALSE, cache = FALSE}
 knitr::opts_chunk$set(warning = FALSE, message = FALSE, echo = FALSE, comment = NA, results = 'asis', cache = FALSE)
 
-main <- '/private/var/folders/wy/svb7d7bx3dlcm68nkktbghvm0000gn/T/RtmpfIxfqh/file4b232a2c737d/output'
+main <- '/private/var/folders/rb/_krf3xys2b7dztjbhm_cpj0m0000gn/T/RtmpkTOZVx/file4afd6427191/output'
 sub <- ''
 ```
 

--- a/tests/testthat/test-blocks.R
+++ b/tests/testthat/test-blocks.R
@@ -12,7 +12,7 @@ test_that("blocks", {
   subfoldr2::sbf_save_block(y, caption = "jags")
   
   txt <- sbr_blocks()
-  expect_identical(txt, "\n```\n.\n  model {\n    for(i in 1:N)\n      bEffect ~ dnorm(0, 2^-2)\n  }\n..\n```\nBlock 1. jags.\n")
+  expect_identical(txt, "\n```\n.\n\n  model {\n    for(i in 1:N)\n      bEffect ~ dnorm(0, 2^-2)\n  }\n..\n```\nBlock 1. jags.\n")
   expect_identical(sbr_blocks(x_name = "y"), txt)
   expect_identical(sbr_blocks(x_name = "z"), character(0))
   expect_identical(list.files(sbr_get_report(), recursive = TRUE), "blocks/y.txt")


### PR DESCRIPTION
Rendered versions of PDFs with model blocks with long lines (e.g. https://github.com/poissonconsulting/infrastructure-issues/issues/114) weren't wrapping because the string matching in poisreport assumed that model blocks started with a new line (\n).

Adding an extra new line between the "." used to denote the start of a model code block ensures that this will be recognized correctly in poisreport.