### PR TITLE
Load figures *after* dropping the unwanted ones

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     purrr,
     rmarkdown,
     stringr,
-    subfoldr2 (>= 1.0.1.9003),
+    subfoldr2 (>= 1.0.1.9006),
     term,
     utils,
     yesno,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     purrr,
     rmarkdown,
     stringr,
-    subfoldr2 (>= 1.0.1.9000),
+    subfoldr2 (>= 1.0.1.9003),
     term,
     utils,
     yesno,

--- a/R/figures.R
+++ b/R/figures.R
@@ -78,9 +78,6 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   plots <- keep_sub(plots, keep = keep)
   windows <- keep_sub(windows, keep = keep)
   
-  plots <- drop_sub(plots, drop = drop)
-  windows <- drop_sub(windows, drop = drop)
-  
   plots <- plots[grepl(x_name, plots$name), ]
   windows <- windows[grepl(x_name, windows$name), ]
   

--- a/R/figures.R
+++ b/R/figures.R
@@ -4,13 +4,12 @@
 #' If a window and plot have identical names then the plot is dropped.
 #'
 #' @inheritParams sbr_tables
-#' @param return_filenames whether to return the file names as a check (defaults to `FALSE`).
 #' @param width A number of the page width in inches.
 #' @param pre_num A count specifying the number of pre-existing items.
 #' @return A string of the plots in markdown format.
 #' @export
 sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                        tag = ".*", return_filenames = FALSE,
+                        tag = ".*",
                         drop = NULL, keep = NULL, sort = NULL, rename = NULL,
                         nheaders = 2L, header1 = 4L,
                         main = subfoldr2::sbf_get_main(),
@@ -48,20 +47,6 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   chk_count(pre_num)
 
   nheaders <- min(nheaders, (7L - header1))
-  
-  if(isTRUE(return_filenames)) {
-    files <- list.files(
-      subfoldr2:::file_path(subfoldr2:::sanitize_path(main, rm_leading = FALSE),
-                            'plots',
-                            subfoldr2:::sanitize_path(sub)),
-      pattern = '[.]rds$', recursive = TRUE)
-    
-    if(length(drop) > 0) {
-      files <- files[! grepl(pattern = paste0(drop, collapse = '|'), x = files)]
-    }
-    
-    return(files)
-  }
   
   plots <- sbf_load_plots_recursive(
     sub = sub, main = main, meta = TRUE,

--- a/R/figures.R
+++ b/R/figures.R
@@ -69,7 +69,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   )
   windows <- sbf_load_windows_recursive(
     sub = sub, main = main, meta = TRUE,
-    tag = tag
+    tag = tag, drop = drop
   )
   
   plots <- rename_sub_sub1(plots)

--- a/R/figures.R
+++ b/R/figures.R
@@ -67,7 +67,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   
   plots <- sbf_load_plots_recursive(
     sub = sub, main = main, meta = TRUE,
-    tag = tag
+    tag = tag, drop = drop
   )
   windows <- sbf_load_windows_recursive(
     sub = sub, main = main, meta = TRUE,

--- a/R/figures.R
+++ b/R/figures.R
@@ -57,9 +57,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
       pattern = '[.]rds$', recursive = TRUE)
     
     if(length(drop) > 0) {
-      files <- stringr::str_subset(files,
-                                   pattern = paste0(drop, collapse = '|'),
-                                   negate = TRUE)
+      files <- files[! grepl(pattern = paste0(drop, collapse = '|'), x = files)]
     }
     
     return(files)

--- a/R/figures.R
+++ b/R/figures.R
@@ -4,12 +4,13 @@
 #' If a window and plot have identical names then the plot is dropped.
 #'
 #' @inheritParams sbr_tables
+#' @param return_filenames whether to return the file names as a check (defaults to `FALSE`).
 #' @param width A number of the page width in inches.
 #' @param pre_num A count specifying the number of pre-existing items.
 #' @return A string of the plots in markdown format.
 #' @export
 sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                        tag = ".*",
+                        tag = ".*", return_filenames = FALSE,
                         drop = NULL, keep = NULL, sort = NULL, rename = NULL,
                         nheaders = 2L, header1 = 4L,
                         main = subfoldr2::sbf_get_main(),
@@ -47,7 +48,23 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   chk_count(pre_num)
 
   nheaders <- min(nheaders, (7L - header1))
-
+  
+  if(isTRUE(return_filenames)) {
+    files <- list.files(
+      subfoldr2:::file_path(subfoldr2:::sanitize_path(main, rm_leading = FALSE),
+                            'plots',
+                            subfoldr2:::sanitize_path(sub)),
+      pattern = '[.]rds$', recursive = TRUE)
+    
+    if(length(drop) > 0) {
+      files <- stringr::str_subset(files,
+                                   pattern = paste0(drop, collapse = '|'),
+                                   negate = TRUE)
+    }
+    
+    return(files)
+  }
+  
   plots <- sbf_load_plots_recursive(
     sub = sub, main = main, meta = TRUE,
     tag = tag

--- a/R/figures.R
+++ b/R/figures.R
@@ -23,7 +23,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_vector(drop)
     check_values(drop, "")
   }
-    if (!is.null(keep)) {
+  if (!is.null(keep)) {
     chk_vector(keep)
     check_values(keep, "")
   }
@@ -38,7 +38,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_unique(rename)
     chk_named(rename)
   }
-
+  
   chk_scalar(nheaders)
   chk_range(nheaders, c(0L, 5L))
   chk_scalar(header1)
@@ -46,7 +46,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   chk_scalar(width)
   chk_range(width, c(1, 24))
   chk_count(pre_num)
-
+  
   nheaders <- min(nheaders, (7L - header1))
   
   if(isTRUE(return_filenames)) {
@@ -73,25 +73,25 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     sub = sub, main = main, meta = TRUE,
     tag = tag
   )
-
+  
   plots <- rename_sub_sub1(plots)
   windows <- rename_sub_sub1(windows)
-
+  
   plots <- keep_sub(plots, keep = keep)
   windows <- keep_sub(windows, keep = keep)
   
   plots <- drop_sub(plots, drop = drop)
   windows <- drop_sub(windows, drop = drop)
-
+  
   plots <- plots[grepl(x_name, plots$name), ]
   windows <- windows[grepl(x_name, windows$name), ]
-
+  
   if (!nrow(windows) && !nrow(plots)) {
     return(character(0))
   }
-
+  
   plots <- drop_duplicate_sub_colnames(plots, windows)
-
+  
   if (nrow(windows)) {
     windows <- transfer_files(windows, ext = "png", report = report, class = "plots")
   }
@@ -100,7 +100,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     plots <- transfer_files(plots, report = report, ext = "png")
   }
   colnames(windows)[1] <- "plots"
-
+  
   if (!nrow(windows)) {
     data <- plots
   } else if (!nrow(plots)) {
@@ -108,28 +108,28 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   } else {
     data <- data.table::rbindlist(list(plots, windows), fill = TRUE)
   }
-
+  
   data <- sort_sub(data, sort = sort)
   data <- rename_sub(data, rename)
-
+  
   data <- set_headings(data, nheaders, header1)
-
+  
   data$caption <- p0("Figure ", 1:nrow(data) + pre_num, ". ", data$caption)
   data$caption <- add_full_stop(data$caption)
   data$width <- data$width / width * 100
-
+  
   txt <- character(0)
   for (i in seq_len(nrow(data))) {
     heading <- data$heading[i]
     caption <- data$caption[i]
     width <- data$width[i]
     to <- data$to[i]
-
+    
     img <- p0(
       "<img alt = \"", to, "\" src = \"", to,
       "\" title = \"", to, "\" width = \"", width, "%\">"
     )
-
+    
     caption <- p0("<figcaption>", caption, "</figcaption>")
     txt <- c(txt, heading, "<figure>", img, caption, "</figure>")
   }

--- a/R/figures.R
+++ b/R/figures.R
@@ -23,7 +23,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_vector(drop)
     check_values(drop, "")
   }
-  if (!is.null(keep)) {
+    if (!is.null(keep)) {
     chk_vector(keep)
     check_values(keep, "")
   }
@@ -38,7 +38,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_unique(rename)
     chk_named(rename)
   }
-  
+
   chk_scalar(nheaders)
   chk_range(nheaders, c(0L, 5L))
   chk_scalar(header1)
@@ -46,7 +46,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   chk_scalar(width)
   chk_range(width, c(1, 24))
   chk_count(pre_num)
-  
+
   nheaders <- min(nheaders, (7L - header1))
   
   if(isTRUE(return_filenames)) {
@@ -71,22 +71,22 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     sub = sub, main = main, meta = TRUE,
     tag = tag, drop = drop
   )
-  
+
   plots <- rename_sub_sub1(plots)
   windows <- rename_sub_sub1(windows)
-  
+
   plots <- keep_sub(plots, keep = keep)
   windows <- keep_sub(windows, keep = keep)
   
   plots <- plots[grepl(x_name, plots$name), ]
   windows <- windows[grepl(x_name, windows$name), ]
-  
+
   if (!nrow(windows) && !nrow(plots)) {
     return(character(0))
   }
-  
+
   plots <- drop_duplicate_sub_colnames(plots, windows)
-  
+
   if (nrow(windows)) {
     windows <- transfer_files(windows, ext = "png", report = report, class = "plots")
   }
@@ -95,7 +95,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     plots <- transfer_files(plots, report = report, ext = "png")
   }
   colnames(windows)[1] <- "plots"
-  
+
   if (!nrow(windows)) {
     data <- plots
   } else if (!nrow(plots)) {
@@ -103,28 +103,28 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   } else {
     data <- data.table::rbindlist(list(plots, windows), fill = TRUE)
   }
-  
+
   data <- sort_sub(data, sort = sort)
   data <- rename_sub(data, rename)
-  
+
   data <- set_headings(data, nheaders, header1)
-  
+
   data$caption <- p0("Figure ", 1:nrow(data) + pre_num, ". ", data$caption)
   data$caption <- add_full_stop(data$caption)
   data$width <- data$width / width * 100
-  
+
   txt <- character(0)
   for (i in seq_len(nrow(data))) {
     heading <- data$heading[i]
     caption <- data$caption[i]
     width <- data$width[i]
     to <- data$to[i]
-    
+
     img <- p0(
       "<img alt = \"", to, "\" src = \"", to,
       "\" title = \"", to, "\" width = \"", width, "%\">"
     )
-    
+
     caption <- p0("<figcaption>", caption, "</figcaption>")
     txt <- c(txt, heading, "<figure>", img, caption, "</figure>")
   }

--- a/man/sbr_figures.Rd
+++ b/man/sbr_figures.Rd
@@ -9,6 +9,7 @@ sbr_figures(
   sub = character(0),
   report = sbr_get_report(),
   tag = ".*",
+  return_filenames = FALSE,
   drop = NULL,
   keep = NULL,
   sort = NULL,
@@ -28,6 +29,8 @@ sbr_figures(
 \item{report}{A string of the path to the report folder.}
 
 \item{tag}{A string of the regular expression that the tag must match to be included.}
+
+\item{return_filenames}{whether to return the file names as a check (defaults to \code{FALSE}).}
 
 \item{drop}{A character vector specifying the sub folders and file names to exclude from the report or NULL.}
 

--- a/man/sbr_figures.Rd
+++ b/man/sbr_figures.Rd
@@ -9,7 +9,6 @@ sbr_figures(
   sub = character(0),
   report = sbr_get_report(),
   tag = ".*",
-  return_filenames = FALSE,
   drop = NULL,
   keep = NULL,
   sort = NULL,
@@ -29,8 +28,6 @@ sbr_figures(
 \item{report}{A string of the path to the report folder.}
 
 \item{tag}{A string of the regular expression that the tag must match to be included.}
-
-\item{return_filenames}{whether to return the file names as a check (defaults to \code{FALSE}).}
 
 \item{drop}{A character vector specifying the sub folders and file names to exclude from the report or NULL.}
 

--- a/tests/testthat/test-figures.R
+++ b/tests/testthat/test-figures.R
@@ -126,9 +126,8 @@ test_that("figures pre_num", {
   )
 })
 
-test_that("sbr_figures() lists the correct file names in the md string and the vector of files.", {
+test_that("sbr_figures() lists the correct file names in the md string.", {
   expect_identical(character(0), sbr_figures())
-  expect_identical(character(0), sbr_figures(return_filenames = TRUE))
   
   p1 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(1, 1)) +
@@ -151,20 +150,15 @@ test_that("sbr_figures() lists the correct file names in the md string and the v
   
   # without dropping sub
   input <- sbr_figures(sub = "sub", main = temp_dir)
-  files <- sbr_figures(sub = "sub", main = temp_dir, return_filenames = TRUE)
   
   expect_all_true(c(grepl("plot-1.png", input),
                     grepl("plot-2.png", input),
                     grepl("plot-3.png", input)))
-  expect_equal(c("plot-1.rds", "plot-2.rds", "plot-3.rds"), files)
   
   # dropping sub
   input <- sbr_figures(main = temp_dir, drop = "sub", report = paste0(temp_dir, "/report"))
-  files <- sbr_figures(main = temp_dir, return_filenames = TRUE, drop = "sub",
-                       report = temp_dir)
   
   expect_equal(input, character(0))
-  expect_equal(files, character(0))
   
   file.remove(list.files("report", pattern = "plot-", recursive = TRUE, full.names = TRUE))
   file.remove(list.files("report", pattern = "\\.DS_Store", recursive = TRUE,

--- a/tests/testthat/test-figures.R
+++ b/tests/testthat/test-figures.R
@@ -125,3 +125,48 @@ test_that("figures pre_num", {
     sort(c("plots/x.csv", "plots/x.png"))
   )
 })
+
+test_that("sbr_figures() lists the correct file names in the md string and the vector of files.", {
+  expect_identical(character(0), sbr_figures())
+  expect_identical(character(0), sbr_figures(return_filenames = TRUE))
+  
+  p1 <- ggplot2::ggplot() +
+    ggplot2::geom_point(ggplot2::aes(1, 1)) +
+    ggplot2::ggtitle("Plot 1")
+  p2 <- ggplot2::ggplot() +
+    ggplot2::geom_point(ggplot2::aes(2, 2)) +
+    ggplot2::ggtitle("Plot 2")
+  p3 <- ggplot2::ggplot() +
+    ggplot2::geom_point(ggplot2::aes(3, 3)) +
+    ggplot2::ggtitle("Plot 3")
+  
+  temp_dir <- withr::local_tempdir(pattern = "test-files-", tmpdir = ".")
+  temp_dir <- gsub("\\./", "", temp_dir)
+  
+  sbf_set_main(temp_dir)
+  
+  sbf_save_plot(x = p1, x_name = "plot-1", sub = "sub", main = temp_dir)
+  sbf_save_plot(x = p2, x_name = "plot-2", sub = "sub", main = temp_dir)
+  sbf_save_plot(x = p3, x_name = "plot-3", sub = "sub", main = temp_dir)
+  
+  # without dropping sub
+  input <- sbr_figures(sub = "sub", main = temp_dir)
+  files <- sbr_figures(sub = "sub", main = temp_dir, return_filenames = TRUE)
+  
+  expect_all_true(c(grepl("plot-1.png", input),
+                    grepl("plot-2.png", input),
+                    grepl("plot-3.png", input)))
+  expect_equal(c("plot-1.rds", "plot-2.rds", "plot-3.rds"), files)
+  
+  # dropping sub
+  input <- sbr_figures(main = temp_dir, drop = "sub", report = paste0(temp_dir, "/report"))
+  files <- sbr_figures(main = temp_dir, return_filenames = TRUE, drop = "sub",
+                       report = temp_dir)
+  
+  expect_equal(input, character(0))
+  expect_equal(files, character(0))
+  
+  file.remove(list.files("report", pattern = "plot-", recursive = TRUE, full.names = TRUE))
+  file.remove(list.files("report", pattern = "\\.DS_Store", recursive = TRUE,
+                         full.names = TRUE))
+})


### PR DESCRIPTION
This is dependent on the PR https://github.com/poissonconsulting/subfoldr2/pull/136

Also, we may want to remove
```r
plots <- drop_sub(plots, drop = drop)
windows <- drop_sub(windows, drop = drop)
```
from `figures.R` since it's likely redundant now. I kept it in case it is still necessary. We should also repeat the change for `tables.R` and edit the documentation as necessary. Done in commit 419fa8fc6e91e23545875c3d6cc02abe83444b2b