### PR TITLE
Add CODEOWNERS assigning @joethorley

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joethorley


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning @joethorley as the code owner for all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)