### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^README\.Rmd$
 ^results\.Rmd$
 ^results\.html$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/blocks.R
+++ b/R/blocks.R
@@ -5,10 +5,19 @@
 #' @inheritParams sbr_tables
 #' @return A string of the code blocks in markdown format.
 #' @export
-sbr_blocks <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                       tag = ".*", drop = NULL, keep = NULL, sort = NULL, rename = NULL,
-                       nheaders = 2L, header1 = 4L,
-                       main = subfoldr2::sbf_get_main()) {
+sbr_blocks <- function(
+  x_name = ".*",
+  sub = character(0),
+  report = sbr_get_report(),
+  tag = ".*",
+  drop = NULL,
+  keep = NULL,
+  sort = NULL,
+  rename = NULL,
+  nheaders = 2L,
+  header1 = 4L,
+  main = subfoldr2::sbf_get_main()
+) {
   chk_string(x_name)
   chk_string(report)
   chk_string(tag)
@@ -41,7 +50,9 @@ sbr_blocks <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
   nheaders <- min(nheaders, (7L - header1))
 
   data <- sbf_load_blocks_recursive(
-    sub = sub, main = main, meta = TRUE,
+    sub = sub,
+    main = main,
+    meta = TRUE,
     tag = tag
   )
 
@@ -65,7 +76,9 @@ sbr_blocks <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
   data$caption <- p0("Block ", 1:nrow(data), ". ", data$caption)
   data$caption <- add_full_stop(data$caption)
 
-  data$blocks <- purrr::map(data$blocks, \(x) stringr::str_replace(x, "^\\{", " {"))
+  data$blocks <- purrr::map(data$blocks, \(x) {
+    stringr::str_replace(x, "^\\{", " {")
+  })
   data$blocks <- p0("```\n.\n", data$blocks, "\n..\n```")
 
   txt <- character(0)

--- a/R/figures.R
+++ b/R/figures.R
@@ -8,13 +8,21 @@
 #' @param pre_num A count specifying the number of pre-existing items.
 #' @return A string of the plots in markdown format.
 #' @export
-sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                        tag = ".*",
-                        drop = NULL, keep = NULL, sort = NULL, rename = NULL,
-                        nheaders = 2L, header1 = 4L,
-                        main = subfoldr2::sbf_get_main(),
-                        width = 6,
-                        pre_num = getOption("sbr.pre_num_fig", 0L)) {
+sbr_figures <- function(
+  x_name = ".*",
+  sub = character(0),
+  report = sbr_get_report(),
+  tag = ".*",
+  drop = NULL,
+  keep = NULL,
+  sort = NULL,
+  rename = NULL,
+  nheaders = 2L,
+  header1 = 4L,
+  main = subfoldr2::sbf_get_main(),
+  width = 6,
+  pre_num = getOption("sbr.pre_num_fig", 0L)
+) {
   chk_string(x_name)
   chk_string(report)
   chk_string(tag)
@@ -22,7 +30,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_vector(drop)
     check_values(drop, "")
   }
-    if (!is.null(keep)) {
+  if (!is.null(keep)) {
     chk_vector(keep)
     check_values(keep, "")
   }
@@ -47,14 +55,20 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   chk_count(pre_num)
 
   nheaders <- min(nheaders, (7L - header1))
-  
+
   plots <- sbf_load_plots_recursive(
-    sub = sub, main = main, meta = TRUE,
-    tag = tag, drop = drop
+    sub = sub,
+    main = main,
+    meta = TRUE,
+    tag = tag,
+    drop = drop
   )
   windows <- sbf_load_windows_recursive(
-    sub = sub, main = main, meta = TRUE,
-    tag = tag, drop = drop
+    sub = sub,
+    main = main,
+    meta = TRUE,
+    tag = tag,
+    drop = drop
   )
 
   plots <- rename_sub_sub1(plots)
@@ -62,7 +76,7 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
 
   plots <- keep_sub(plots, keep = keep)
   windows <- keep_sub(windows, keep = keep)
-  
+
   plots <- plots[grepl(x_name, plots$name), ]
   windows <- windows[grepl(x_name, windows$name), ]
 
@@ -73,7 +87,12 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   plots <- drop_duplicate_sub_colnames(plots, windows)
 
   if (nrow(windows)) {
-    windows <- transfer_files(windows, ext = "png", report = report, class = "plots")
+    windows <- transfer_files(
+      windows,
+      ext = "png",
+      report = report,
+      class = "plots"
+    )
   }
   if (nrow(plots)) {
     transfer_files(plots, report = report, ext = "csv")
@@ -106,8 +125,15 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     to <- data$to[i]
 
     img <- p0(
-      "<img alt = \"", to, "\" src = \"", to,
-      "\" title = \"", to, "\" width = \"", width, "%\">"
+      "<img alt = \"",
+      to,
+      "\" src = \"",
+      to,
+      "\" title = \"",
+      to,
+      "\" width = \"",
+      width,
+      "%\">"
     )
 
     caption <- p0("<figcaption>", caption, "</figcaption>")

--- a/R/internal.R
+++ b/R/internal.R
@@ -18,7 +18,9 @@ file_path <- function(..., collapse = FALSE) {
 sanitize_path <- function(path, rm_leading = TRUE) {
   path <- sub("//", "/", path)
   path <- sub("(.+)(/$)", "\\1", path)
-  if (isTRUE(rm_leading)) path <- sub("(^/)(.*)", "\\2", path)
+  if (isTRUE(rm_leading)) {
+    path <- sub("(^/)(.*)", "\\2", path)
+  }
   path
 }
 
@@ -88,7 +90,9 @@ write_txt <- function(x, file) {
 sub_colnames <- function(data, names = TRUE) {
   colnames <- colnames(data)
   colnames <- colnames[grepl("^sub\\d+", colnames)]
-  if (isTRUE(names)) colnames <- c(colnames, "name")
+  if (isTRUE(names)) {
+    colnames <- c(colnames, "name")
+  }
   colnames
 }
 
@@ -118,7 +122,7 @@ keep_sub <- function(data, keep) {
 
   colnames <- sub_colnames(data)
   data <- data[data[[colnames[1]]] %in% keep, ]
-  
+
   data
 }
 
@@ -198,7 +202,14 @@ new_only_across_section <- function(matrix) {
     if (col == 1L) {
       new_data[which(duplicated(data[, col])), col] <- NA
     } else {
-      new_data[as.logical(stats::ave(data[, col], data[, 1:(col - 1)], FUN = duplicated)), col] <- NA
+      new_data[
+        as.logical(stats::ave(
+          data[, col],
+          data[, 1:(col - 1)],
+          FUN = duplicated
+        )),
+        col
+      ] <- NA
     }
     col <- col + 1L
   }
@@ -252,7 +263,9 @@ set_headings <- function(data, nheaders, header1) {
   heading[is.na(heading)] <- ""
 
   heading <- as.matrix(heading)
-  if (!is.null(row.names(heading))) heading <- t(heading)
+  if (!is.null(row.names(heading))) {
+    heading <- t(heading)
+  }
   heading <- apply(heading, MARGIN = 1, p0, collapse = "")
 
   data$heading <- heading

--- a/R/knit.R
+++ b/R/knit.R
@@ -12,13 +12,15 @@
 #' @param browse A flag specifying whether to open the .html file in a web browser.
 #' @return An invisible path to the .Rmd file.
 #' @export
-sbr_knit_results <- function(file = "results",
-                             report = sbr_get_report(),
-                             sub = character(0),
-                             main = subfoldr2::sbf_get_main(),
-                             quiet = FALSE,
-                             browse = TRUE,
-                             browser = "open") {
+sbr_knit_results <- function(
+  file = "results",
+  report = sbr_get_report(),
+  sub = character(0),
+  main = subfoldr2::sbf_get_main(),
+  quiet = FALSE,
+  browse = TRUE,
+  browser = "open"
+) {
   chk_string(file)
   chk_string(report)
   check_values(sub, "")

--- a/R/numbers.R
+++ b/R/numbers.R
@@ -6,10 +6,20 @@
 #' @param numbered A flag specifying whether the list(s) items should be numbered.
 #' @return A string of the numbers in markdown format.
 #' @export
-sbr_numbers <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                        tag = ".*", drop = NULL, keep = NULL, sort = NULL, rename = NULL,
-                        nheaders = 2L, header1 = 4L, numbered = FALSE,
-                        main = subfoldr2::sbf_get_main()) {
+sbr_numbers <- function(
+  x_name = ".*",
+  sub = character(0),
+  report = sbr_get_report(),
+  tag = ".*",
+  drop = NULL,
+  keep = NULL,
+  sort = NULL,
+  rename = NULL,
+  nheaders = 2L,
+  header1 = 4L,
+  numbered = FALSE,
+  main = subfoldr2::sbf_get_main()
+) {
   chk_string(x_name)
   chk_string(report)
   chk_string(tag)
@@ -18,7 +28,7 @@ sbr_numbers <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_vector(drop)
     check_values(drop, "")
   }
-    if (!is.null(keep)) {
+  if (!is.null(keep)) {
     chk_vector(keep)
     check_values(keep, "")
   }
@@ -43,7 +53,9 @@ sbr_numbers <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   nheaders <- min(nheaders, (7L - header1))
 
   data <- sbf_load_numbers_recursive(
-    sub = sub, main = main, meta = TRUE,
+    sub = sub,
+    main = main,
+    meta = TRUE,
     tag = tag
   )
   data <- rename_sub_sub1(data)

--- a/R/report-text.R
+++ b/R/report-text.R
@@ -1,15 +1,23 @@
 report_text <- function(sub, main) {
   paste0(
     "---
-title: '", basename(getwd()), "'
-date: ", Sys.time(), "
+title: '",
+    basename(getwd()),
+    "'
+date: ",
+    Sys.time(),
+    "
 ---
 
 ```{r, echo = FALSE, warning = FALSE, message = FALSE, include = FALSE, cache = FALSE}
 knitr::opts_chunk$set(warning = FALSE, message = FALSE, echo = FALSE, comment = NA, results = 'asis', cache = FALSE)
 
-main <- '", normalizePath(main, winslash = "/"), "'
-sub <- '", sub, "'
+main <- '",
+    normalizePath(main, winslash = "/"),
+    "'
+sub <- '",
+    sub,
+    "'
 ```
 
 ## Results

--- a/R/report.R
+++ b/R/report.R
@@ -23,7 +23,9 @@ sbr_set_report <- function(..., rm = FALSE, ask = getOption("sbf.ask", TRUE)) {
   path <- file_path(...)
   path <- sanitize_path(path, rm_leading = FALSE)
   options(sbr.report = path)
-  if (rm) rm_all(ask = ask)
+  if (rm) {
+    rm_all(ask = ask)
+  }
   invisible(path)
 }
 

--- a/R/rm.R
+++ b/R/rm.R
@@ -9,6 +9,8 @@ rm_all <- function(ask) {
 
   msg <- paste0("Delete directory '", report, "'?")
 
-  if (!ask || yesno(msg)) unlink(report, recursive = TRUE)
+  if (!ask || yesno(msg)) {
+    unlink(report, recursive = TRUE)
+  }
   NULL
 }

--- a/R/strings.R
+++ b/R/strings.R
@@ -6,10 +6,20 @@
 #' @param numbered A flag specifying whether the list(s) items should be numbered.
 #' @return A string of the code blocks in markdown format.
 #' @export
-sbr_strings <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                        tag = ".*", drop = NULL, keep = NULL, sort = NULL, rename = NULL,
-                        nheaders = 2L, header1 = 4L, numbered = FALSE,
-                        main = subfoldr2::sbf_get_main()) {
+sbr_strings <- function(
+  x_name = ".*",
+  sub = character(0),
+  report = sbr_get_report(),
+  tag = ".*",
+  drop = NULL,
+  keep = NULL,
+  sort = NULL,
+  rename = NULL,
+  nheaders = 2L,
+  header1 = 4L,
+  numbered = FALSE,
+  main = subfoldr2::sbf_get_main()
+) {
   chk_string(x_name)
   chk_string(report)
   chk_string(tag)
@@ -18,7 +28,7 @@ sbr_strings <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
     chk_vector(drop)
     check_values(drop, "")
   }
-    if (!is.null(keep)) {
+  if (!is.null(keep)) {
     chk_vector(keep)
     check_values(keep, "")
   }
@@ -43,7 +53,9 @@ sbr_strings <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   nheaders <- min(nheaders, (7L - header1))
 
   data <- sbf_load_strings_recursive(
-    sub = sub, main = main, meta = TRUE,
+    sub = sub,
+    main = main,
+    meta = TRUE,
     tag = tag
   )
   data <- rename_sub_sub1(data)

--- a/R/tables.R
+++ b/R/tables.R
@@ -19,12 +19,21 @@
 #' @param sigfig_override A named vector of table names and the number of significant figures to use. This will override the default set in `sigfig` for matching tables.
 #' @return A string of the tables in markdown format.
 #' @export
-sbr_tables <- function(x_name = ".*", sub = character(0), report = sbr_get_report(),
-                       tag = ".*", drop = NULL, keep = NULL, sort = NULL, rename = NULL,
-                       nheaders = 2L, header1 = 4L,
-                       main = subfoldr2::sbf_get_main(),
-                       sigfig = 4L,
-                       sigfig_override = NULL) {
+sbr_tables <- function(
+  x_name = ".*",
+  sub = character(0),
+  report = sbr_get_report(),
+  tag = ".*",
+  drop = NULL,
+  keep = NULL,
+  sort = NULL,
+  rename = NULL,
+  nheaders = 2L,
+  header1 = 4L,
+  main = subfoldr2::sbf_get_main(),
+  sigfig = 4L,
+  sigfig_override = NULL
+) {
   chk_string(x_name)
   chk_string(report)
   chk_string(tag)
@@ -32,7 +41,7 @@ sbr_tables <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
     chk_vector(drop)
     check_values(drop, "")
   }
-    if (!is.null(keep)) {
+  if (!is.null(keep)) {
     chk_vector(keep)
     check_values(keep, "")
   }
@@ -63,7 +72,9 @@ sbr_tables <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
   nheaders <- min(nheaders, (7L - header1))
 
   data <- sbf_load_tables_recursive(
-    sub = sub, main = main, meta = TRUE,
+    sub = sub,
+    main = main,
+    meta = TRUE,
     tag = tag
   )
   data <- rename_sub_sub1(data)
@@ -103,7 +114,8 @@ sbr_tables <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
       table <- signif_table(table, sigfig = sigfig)
     }
 
-    table <- knitr::kable(table,
+    table <- knitr::kable(
+      table,
       format = "markdown",
       row.names = FALSE,
       align = alignment

--- a/R/use.R
+++ b/R/use.R
@@ -1,7 +1,7 @@
 #' Use Report File
 #'
 #' Creates a report.Rmd file in the root directory.
-#' 
+#'
 #' @export
 sbr_use_report <- function() {
   usethis::use_template(
@@ -13,7 +13,7 @@ sbr_use_report <- function() {
 #' Use Bibliography
 #'
 #' Creates a bibliography.bib file in the root directory.
-#' 
+#'
 #' @export
 sbr_use_bibliography <- function() {
   usethis::use_template(
@@ -25,7 +25,7 @@ sbr_use_bibliography <- function() {
 #' Use Knit Report
 #'
 #' Creates a knit-report.R file in the root directory.
-#' 
+#'
 #' @export
 sbr_use_knit_report <- function() {
   usethis::use_template(
@@ -38,7 +38,7 @@ sbr_use_knit_report <- function() {
 #'
 #' Creates knit-report.R, bibliography.bib and and knit-report.R files
 #'  in the root directory.
-#' 
+#'
 #' @export
 sbr_use_knit_report_all <- function() {
   sbr_use_report()

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-blocks.R
+++ b/tests/testthat/test-blocks.R
@@ -12,10 +12,16 @@ test_that("blocks", {
   subfoldr2::sbf_save_block(y, caption = "jags")
 
   txt <- sbr_blocks()
-  expect_identical(txt, "\n```\n.\n\n  model {\n    for(i in 1:N)\n      bEffect ~ dnorm(0, 2^-2)\n  }\n..\n```\nBlock 1. jags.\n")
+  expect_identical(
+    txt,
+    "\n```\n.\n\n  model {\n    for(i in 1:N)\n      bEffect ~ dnorm(0, 2^-2)\n  }\n..\n```\nBlock 1. jags.\n"
+  )
   expect_identical(sbr_blocks(x_name = "y"), txt)
   expect_identical(sbr_blocks(x_name = "z"), character(0))
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "blocks/y.txt")
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    "blocks/y.txt"
+  )
 
   y_txt <- readLines(file.path(sbr_get_report(), "blocks/y.txt"))
   y_txt <- paste0(y_txt, collapse = "\n")

--- a/tests/testthat/test-figures.R
+++ b/tests/testthat/test-figures.R
@@ -10,7 +10,10 @@ test_that("figures", {
 
   options(warn = 2)
   txt <- sbr_figures()
-  expect_match(txt, "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 1. A ggplot.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 1. A ggplot.</figcaption>\n</figure>\n"
+  )
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
     sort(c("plots/x.csv", "plots/x.png"))
@@ -23,7 +26,10 @@ test_that("figures", {
   subfoldr2::sbf_close_window()
 
   txt <- sbr_figures()
-  expect_match(txt, "\n<figure>\n<img alt = \".*plots/x.png\" width = \"100%\">\n<figcaption>Figure 2. A ggplot.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = \".*plots/x.png\" width = \"100%\">\n<figcaption>Figure 2. A ggplot.</figcaption>\n</figure>\n"
+  )
 
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
@@ -33,13 +39,18 @@ test_that("figures", {
   subfoldr2::sbf_open_window()
   plot(x ~ y, data = data.frame(x = c(5, 4), y = c(6, 7)))
   subfoldr2::sbf_save_window(
-    x_name = "x", width = 12L, dpi = 300L,
+    x_name = "x",
+    width = 12L,
+    dpi = 300L,
     caption = "the window one"
   )
   subfoldr2::sbf_close_window()
 
   txt <- sbr_figures()
-  expect_match(txt, "\n<figure>\n<img alt = \".*plots/x.png\" width = \"200%\">\n<figcaption>Figure 2. the window one.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = \".*plots/x.png\" width = \"200%\">\n<figcaption>Figure 2. the window one.</figcaption>\n</figure>\n"
+  )
   expect_identical(sbr_figures(x_name = ".*.*"), txt)
 })
 
@@ -59,18 +70,31 @@ test_that("figures sort sub and name", {
   subfoldr2::sbf_save_plot(standard, sub = "90 mm")
 
   txt <- sbr_figures(pre_num = 0L)
-  expect_match(txt, "\n<figure>\n<img alt = .* width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n\n#### 90 Mm\n\n<figure>\n<img alt = .*report/plots/90 mm/standard.png\" width = \"100%\">\n<figcaption>Figure 2.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = .* width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n\n#### 90 Mm\n\n<figure>\n<img alt = .*report/plots/90 mm/standard.png\" width = \"100%\">\n<figcaption>Figure 2.</figcaption>\n</figure>\n"
+  )
 
   txt <- sbr_figures(
     sort = c("allometry", "90mm", "standard"),
     pre_num = 0L
   )
 
-  expect_match(txt, "\n<figure>\n<img alt = .* width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n\n#### 90 Mm\n\n<figure>\n<img alt = .*report/plots/90 mm/standard.png\" width = \"100%\">\n<figcaption>Figure 2.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = .* width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n\n#### 90 Mm\n\n<figure>\n<img alt = .*report/plots/90 mm/standard.png\" width = \"100%\">\n<figcaption>Figure 2.</figcaption>\n</figure>\n"
+  )
 
-  txt <- sbr_figures(x_name = "allometry", sort = c("allometry", "90 mm", "standard"), pre_num = 0L)
+  txt <- sbr_figures(
+    x_name = "allometry",
+    sort = c("allometry", "90 mm", "standard"),
+    pre_num = 0L
+  )
 
-  expect_match(txt, "\n<figure>\n<img alt = .*report/plots//allometry.png\" width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = .*report/plots//allometry.png\" width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n"
+  )
 })
 
 test_that("figures different sub lengths windows and plots", {
@@ -94,11 +118,17 @@ test_that("figures different sub lengths windows and plots", {
 
   txt <- sbr_figures(x_name = "allometry")
 
-  expect_match(txt, "\n#### One\n\n##### Two\n\n<figure>\n<img alt = .*report/plots/one/two/allometry.png\" src = .*report/plots/one/two/allometry.png\" title = .*report/plots/one/two/allometry.png\" width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n#### One\n\n##### Two\n\n<figure>\n<img alt = .*report/plots/one/two/allometry.png\" src = .*report/plots/one/two/allometry.png\" title = .*report/plots/one/two/allometry.png\" width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n"
+  )
 
   txt <- sbr_figures()
 
-  expect_match(txt, "\n#### One\n\n##### Two\n\n<figure>\n<img alt = .*report/plots/one/two/allometry.png\" src = .*report/plots/one/two/allometry.png\" title = .*report/plots/one/two/allometry.png\" width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n\n<figure>\n<img alt = .*report/plots/one/two/three/window.png\" src = .*report/plots/one/two/three/window.png\" title = .*report/plots/one/two/three/window.png\" width = \"100%\">\n<figcaption>Figure 2.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n#### One\n\n##### Two\n\n<figure>\n<img alt = .*report/plots/one/two/allometry.png\" src = .*report/plots/one/two/allometry.png\" title = .*report/plots/one/two/allometry.png\" width = \"100%\">\n<figcaption>Figure 1. Length weight.</figcaption>\n</figure>\n\n<figure>\n<img alt = .*report/plots/one/two/three/window.png\" src = .*report/plots/one/two/three/window.png\" title = .*report/plots/one/two/three/window.png\" width = \"100%\">\n<figcaption>Figure 2.</figcaption>\n</figure>\n"
+  )
 })
 
 test_that("figures pre_num", {
@@ -113,13 +143,19 @@ test_that("figures pre_num", {
 
   options(warn = 2)
   txt <- sbr_figures(pre_num = 0)
-  expect_match(txt, "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 1. A ggplot.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 1. A ggplot.</figcaption>\n</figure>\n"
+  )
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
     sort(c("plots/x.csv", "plots/x.png"))
   )
   txt <- sbr_figures()
-  expect_match(txt, "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 2. A ggplot.</figcaption>\n</figure>\n")
+  expect_match(
+    txt,
+    "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 2. A ggplot.</figcaption>\n</figure>\n"
+  )
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
     sort(c("plots/x.csv", "plots/x.png"))
@@ -128,7 +164,7 @@ test_that("figures pre_num", {
 
 test_that("sbr_figures() lists the correct file names in the md string.", {
   expect_identical(character(0), sbr_figures())
-  
+
   p1 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(1, 1)) +
     ggplot2::ggtitle("Plot 1")
@@ -138,29 +174,44 @@ test_that("sbr_figures() lists the correct file names in the md string.", {
   p3 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(3, 3)) +
     ggplot2::ggtitle("Plot 3")
-  
+
   temp_dir <- withr::local_tempdir(pattern = "test-files-", tmpdir = ".")
   temp_dir <- gsub("\\./", "", temp_dir)
-  
+
   sbf_set_main(temp_dir)
-  
+
   sbf_save_plot(x = p1, x_name = "plot-1", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p2, x_name = "plot-2", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p3, x_name = "plot-3", sub = "sub", main = temp_dir)
-  
+
   # without dropping sub
   input <- sbr_figures(sub = "sub", main = temp_dir)
-  
-  expect_all_true(c(grepl("plot-1.png", input),
-                    grepl("plot-2.png", input),
-                    grepl("plot-3.png", input)))
-  
+
+  expect_all_true(c(
+    grepl("plot-1.png", input),
+    grepl("plot-2.png", input),
+    grepl("plot-3.png", input)
+  ))
+
   # dropping sub
-  input <- sbr_figures(main = temp_dir, drop = "sub", report = paste0(temp_dir, "/report"))
-  
+  input <- sbr_figures(
+    main = temp_dir,
+    drop = "sub",
+    report = paste0(temp_dir, "/report")
+  )
+
   expect_equal(input, character(0))
-  
-  file.remove(list.files("report", pattern = "plot-", recursive = TRUE, full.names = TRUE))
-  file.remove(list.files("report", pattern = "\\.DS_Store", recursive = TRUE,
-                         full.names = TRUE))
+
+  file.remove(list.files(
+    "report",
+    pattern = "plot-",
+    recursive = TRUE,
+    full.names = TRUE
+  ))
+  file.remove(list.files(
+    "report",
+    pattern = "\\.DS_Store",
+    recursive = TRUE,
+    full.names = TRUE
+  ))
 })

--- a/tests/testthat/test-numbers.R
+++ b/tests/testthat/test-numbers.R
@@ -33,8 +33,14 @@ test_that("numbers", {
   t <- 10^6
   subfoldr2::sbf_save_number(t, sub = "tori")
   txt <- sbr_numbers()
-  expect_identical(txt, "\n- 1.5: 1.5\n- indx: 1\n- z: -0.1\n\n#### Tori\n\n- t: 1e+06\n")
+  expect_identical(
+    txt,
+    "\n- 1.5: 1.5\n- indx: 1\n- z: -0.1\n\n#### Tori\n\n- t: 1e+06\n"
+  )
 
   txt <- sbr_numbers(numbered = TRUE)
-  expect_identical(txt, "\n1. 1.5: 1.5\n2. indx: 1\n3. z: -0.1\n\n#### Tori\n\n1. t: 1e+06\n")
+  expect_identical(
+    txt,
+    "\n1. 1.5: 1.5\n2. indx: 1\n3. z: -0.1\n\n#### Tori\n\n1. t: 1e+06\n"
+  )
 })

--- a/tests/testthat/test-sigfig.R
+++ b/tests/testthat/test-sigfig.R
@@ -13,14 +13,20 @@ test_that("sigfig function works correctly on various numeric types", {
 
   expect_equal(res$small_decimal, c("1.23e-01", "1.23e-04", "1.99", "1.00e+02"))
   expect_equal(res$large_number, c("1230000", "9880000", "5560", "1000000"))
-  expect_equal(res$scientific, c("1.23e-05", "4.56e+08", "7.89e-10", "2.34e+12"))
+  expect_equal(
+    res$scientific,
+    c("1.23e-05", "4.56e+08", "7.89e-10", "2.34e+12")
+  )
   expect_equal(res$integer, c("123", "456", "789", "0"))
   expect_equal(res$missing, c(NA, NA, NA, NA))
 
   expect_identical(res$character, df$character)
   expect_identical(res$logical, df$logical)
 
-  expect_true(all(sapply(res[c("small_decimal", "large_number", "scientific")], is.character)))
+  expect_true(all(sapply(
+    res[c("small_decimal", "large_number", "scientific")],
+    is.character
+  )))
 })
 
 test_that("sigfig_override and sigfig work as expected", {
@@ -35,14 +41,26 @@ test_that("sigfig_override and sigfig work as expected", {
   subfoldr2::sbf_save_table(x2, x_name = "glance")
 
   txt <- sbr_tables()
-  expect_identical(txt, "\nTable 1.\n\n|x  |       y|\n|:--|-------:|\n|a  | 0.01586|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2025|\n")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|x  |       y|\n|:--|-------:|\n|a  | 0.01586|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2025|\n"
+  )
 
   txt <- sbr_tables(sigfig = 1)
-  expect_identical(txt, "\nTable 1.\n\n|x  |    y|\n|:--|----:|\n|a  | 0.02|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2000|\n")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|x  |    y|\n|:--|----:|\n|a  | 0.02|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2000|\n"
+  )
 
   txt <- sbr_tables(sigfig = 1, sigfig_override = c("coef" = 3))
-  expect_identical(txt, "\nTable 1.\n\n|x  |      y|\n|:--|------:|\n|a  | 0.0159|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2000|\n")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|x  |      y|\n|:--|------:|\n|a  | 0.0159|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2000|\n"
+  )
 
   txt <- sbr_tables(sigfig = 1, sigfig_override = c("coef" = 4, "glance" = 3))
-  expect_identical(txt, "\nTable 1.\n\n|x  |       y|\n|:--|-------:|\n|a  | 0.01586|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2020|\n")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|x  |       y|\n|:--|-------:|\n|a  | 0.01586|\n\nTable 2.\n\n|x  |    y|\n|:--|----:|\n|b  | 2020|\n"
+  )
 })

--- a/tests/testthat/test-strings.R
+++ b/tests/testthat/test-strings.R
@@ -22,10 +22,16 @@ test_that("strings", {
   expect_identical(txt2, txt)
 
   txt <- sbr_strings()
-  expect_identical(txt, "\n- another assumption\n- an assumption\n- not an assumption\n")
+  expect_identical(
+    txt,
+    "\n- another assumption\n- an assumption\n- not an assumption\n"
+  )
 
   txt <- sbr_strings(numbered = TRUE)
-  expect_identical(txt, "\n1. another assumption\n2. an assumption\n3. not an assumption\n")
+  expect_identical(
+    txt,
+    "\n1. another assumption\n2. an assumption\n3. not an assumption\n"
+  )
 
   txt <- sbr_strings(tag = "assumption", numbered = TRUE)
   expect_identical(txt, "\n1. another assumption\n2. an assumption\n")
@@ -33,8 +39,14 @@ test_that("strings", {
   t <- "from another city"
   subfoldr2::sbf_save_string(t, sub = "tori")
   txt <- sbr_strings()
-  expect_identical(txt, "\n- another assumption\n- an assumption\n- not an assumption\n\n#### Tori\n\n- from another city\n")
+  expect_identical(
+    txt,
+    "\n- another assumption\n- an assumption\n- not an assumption\n\n#### Tori\n\n- from another city\n"
+  )
 
   txt <- sbr_strings(numbered = TRUE)
-  expect_identical(txt, "\n1. another assumption\n2. an assumption\n3. not an assumption\n\n#### Tori\n\n1. from another city\n")
+  expect_identical(
+    txt,
+    "\n1. another assumption\n2. an assumption\n3. not an assumption\n\n#### Tori\n\n1. from another city\n"
+  )
 })

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -8,14 +8,21 @@ test_that("tables", {
   subfoldr2::sbf_save_table(x, caption = "Observations")
 
   txt <- sbr_tables()
-  expect_identical(txt, "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/x.csv")
+  expect_identical(
+    txt,
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n"
+  )
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    "tables/x.csv"
+  )
 
   subfoldr2::sbf_save_table(x, x_name = "y", report = FALSE)
   expect_identical(sbr_tables(), txt)
   expect_identical(
     list.files(sbr_get_report(), recursive = TRUE),
-    "tables/x.csv", "tables/y.csv"
+    "tables/x.csv",
+    "tables/y.csv"
   )
 
   x_csv <- utils::read.csv(file.path(sbr_get_report(), "tables/x.csv"))
@@ -49,22 +56,46 @@ test_that("tables", {
   subfoldr2::sbf_save_table(x, caption = "Extra Obs")
   subfoldr2::sbf_save_table(z, caption = "More Sites")
 
-  expect_identical(sbr_tables(nheaders = 0L), "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n")
+  expect_identical(
+    sbr_tables(nheaders = 0L),
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n"
+  )
 
-  expect_identical(sbr_tables(sort = "z", nheaders = 0L), "\nTable 1. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 2. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 3. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 4. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
+  expect_identical(
+    sbr_tables(sort = "z", nheaders = 0L),
+    "\nTable 1. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 2. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 3. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 4. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n"
+  )
 
-  expect_identical(sbr_tables(), "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### RB\n\n##### Max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n")
+  expect_identical(
+    sbr_tables(),
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### RB\n\n##### Max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n"
+  )
 
-  expect_identical(sbr_tables(header1 = 1L), "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n# RB\n\n## Max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n")
+  expect_identical(
+    sbr_tables(header1 = 1L),
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n# RB\n\n## Max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n"
+  )
 
-  expect_identical(sbr_tables(rename = c("max like" = "max Like", "RB" = "Rainbow trout")), "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### Rainbow trout\n\n##### max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n")
+  expect_identical(
+    sbr_tables(rename = c("max like" = "max Like", "RB" = "Rainbow trout")),
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### Rainbow trout\n\n##### max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n"
+  )
 
   subfoldr2::sbf_set_sub("RB", "max like", "number6")
   subfoldr2::sbf_save_table(x, caption = "Tiny")
 
-  expect_identical(sbr_tables(rename = c("max like" = "max Like", "RB" = "Rainbow trout")), "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### Rainbow trout\n\n##### max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 5. Tiny.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
+  expect_identical(
+    sbr_tables(rename = c("max like" = "max Like", "RB" = "Rainbow trout")),
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### Rainbow trout\n\n##### max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\nTable 5. Tiny.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n"
+  )
 
-  expect_identical(sbr_tables(rename = c("max like" = "max Like", "RB" = "Rainbow trout"), nheaders = 3L), "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### Rainbow trout\n\n##### max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n###### Number6\n\nTable 5. Tiny.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
+  expect_identical(
+    sbr_tables(
+      rename = c("max like" = "max Like", "RB" = "Rainbow trout"),
+      nheaders = 3L
+    ),
+    "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 2. Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n#### Rainbow trout\n\n##### max Like\n\nTable 3. Extra Obs.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n\nTable 4. More Sites.\n\n| Site|Name    |\n|----:|:-------|\n|    1|parlour |\n|    2|study   |\n\n###### Number6\n\nTable 5. Tiny.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n"
+  )
 })
 
 test_that("tables sub", {
@@ -77,8 +108,14 @@ test_that("tables sub", {
   subfoldr2::sbf_save_table(x, sub = "A sub", caption = "Observations")
 
   txt <- sbr_tables()
-  expect_identical(txt, "\n#### A Sub\n\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/A sub/x.csv")
+  expect_identical(
+    txt,
+    "\n#### A Sub\n\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n"
+  )
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    "tables/A sub/x.csv"
+  )
 })
 
 test_that("tables missing caption", {
@@ -91,8 +128,14 @@ test_that("tables missing caption", {
   subfoldr2::sbf_save_table(x)
 
   txt <- sbr_tables()
-  expect_identical(txt, "\nTable 1.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/x.csv")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n"
+  )
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    "tables/x.csv"
+  )
 })
 
 test_that("tables sort sub and name", {
@@ -107,14 +150,20 @@ test_that("tables sort sub and name", {
   subfoldr2::sbf_save_table(a, sub = "b")
 
   txt <- sbr_tables()
-  expect_identical(txt, "\nTable 1.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n\n#### B\n\nTable 2.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n\n#### B\n\nTable 2.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n"
+  )
   expect_identical(
     list.files(sbr_get_report(), recursive = TRUE),
     c("tables/a.csv", "tables/b/a.csv")
   )
 
   txt <- sbr_tables(sort = c("b", "a"))
-  expect_identical(txt, "\nTable 1.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n\n#### B\n\nTable 2.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n\n#### B\n\nTable 2.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n"
+  )
 })
 
 test_that("tables with []", {
@@ -127,6 +176,12 @@ test_that("tables with []", {
   subfoldr2::sbf_save_table(x)
 
   txt <- sbr_tables()
-  expect_identical(txt, "\nTable 1.\n\n|term   | count|\n|:------|-----:|\n|par[1] |     1|\n|par[2] |     2|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/x.csv")
+  expect_identical(
+    txt,
+    "\nTable 1.\n\n|term   | count|\n|:------|-----:|\n|par[1] |     1|\n|par[2] |     2|\n"
+  )
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    "tables/x.csv"
+  )
 })

--- a/tests/testthat/test_internal.R
+++ b/tests/testthat/test_internal.R
@@ -13,7 +13,8 @@ test_that("set_headings correctly removes duplicate headings within a section", 
       sub3 = c("Ssh1", "Sh1", "H3"),
       heading = c(
         "\n#### H1\n\n##### Sh1\n\n###### Ssh1\n",
-        "\n#### H2\n\n##### Sh1\n", "\n#### H3\n"
+        "\n#### H2\n\n##### Sh1\n",
+        "\n#### H3\n"
       )
     )
   )
@@ -29,21 +30,60 @@ test_that("set_headings correctly removes duplicate headings across sections", {
   expect_identical(
     set_headings(data, nheaders = nrow(data), header1 = 4L),
     data.frame(
-      sub1 = c("H", "H", "H", "H", "H", "H", "H2", "H2", "H2", "H2", "H2", "H2"),
+      sub1 = c(
+        "H",
+        "H",
+        "H",
+        "H",
+        "H",
+        "H",
+        "H2",
+        "H2",
+        "H2",
+        "H2",
+        "H2",
+        "H2"
+      ),
       sub2 = c(
-        "Sh", "Sh", "Sh", "Sh2", "Sh2", "Sh2", "Sh", "Sh", "Sh", "Sh2",
-        "Sh2", "Sh2"
+        "Sh",
+        "Sh",
+        "Sh",
+        "Sh2",
+        "Sh2",
+        "Sh2",
+        "Sh",
+        "Sh",
+        "Sh",
+        "Sh2",
+        "Sh2",
+        "Sh2"
       ),
       sub3 = c(
-        "Ssh", "Ssh2", "Ssh3", "Ssh", "Ssh2", "Ssh3", "Ssh", "Ssh2",
-        "Ssh3", "Ssh", "Ssh", "Ssh2"
+        "Ssh",
+        "Ssh2",
+        "Ssh3",
+        "Ssh",
+        "Ssh2",
+        "Ssh3",
+        "Ssh",
+        "Ssh2",
+        "Ssh3",
+        "Ssh",
+        "Ssh",
+        "Ssh2"
       ),
       heading = c(
-        "\n#### H\n\n##### Sh\n\n###### Ssh\n", "\n###### Ssh2\n",
-        "\n###### Ssh3\n", "\n##### Sh2\n\n###### Ssh\n",
-        "\n###### Ssh2\n", "\n###### Ssh3\n",
-        "\n#### H2\n\n##### Sh\n\n###### Ssh\n", "\n###### Ssh2\n",
-        "\n###### Ssh3\n", "\n##### Sh2\n\n###### Ssh\n", "",
+        "\n#### H\n\n##### Sh\n\n###### Ssh\n",
+        "\n###### Ssh2\n",
+        "\n###### Ssh3\n",
+        "\n##### Sh2\n\n###### Ssh\n",
+        "\n###### Ssh2\n",
+        "\n###### Ssh3\n",
+        "\n#### H2\n\n##### Sh\n\n###### Ssh\n",
+        "\n###### Ssh2\n",
+        "\n###### Ssh3\n",
+        "\n##### Sh2\n\n###### Ssh\n",
+        "",
         "\n###### Ssh2\n"
       )
     )


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)