### PR TITLE
Transfer yaml metadata and xlsx plot data to report folder

### DIFF
--- a/R/figures.R
+++ b/R/figures.R
@@ -73,10 +73,13 @@ sbr_figures <- function(x_name = ".*", sub = character(0), report = sbr_get_repo
   plots <- drop_duplicate_sub_colnames(plots, windows)
 
   if (nrow(windows)) {
+    transfer_files(windows, ext = "yaml", report = report, class = "plots")
     windows <- transfer_files(windows, ext = "png", report = report, class = "plots")
   }
   if (nrow(plots)) {
     transfer_files(plots, report = report, ext = "csv")
+    transfer_files(plots, report = report, ext = "yaml")
+    transfer_files(plots, report = report, ext = "xlsx")
     plots <- transfer_files(plots, report = report, ext = "png")
   }
   colnames(windows)[1] <- "plots"

--- a/R/tables.R
+++ b/R/tables.R
@@ -77,6 +77,7 @@ sbr_tables <- function(x_name = ".*", sub = character(0), report = sbr_get_repor
     return(character(0))
   }
 
+  transfer_files(data, report = report, ext = "yaml")
   data <- write_files(data, report = report, ext = ".csv", fun = write_csv)
 
   data <- sort_sub(data, sort = sort)

--- a/tests/testthat/test-figures.R
+++ b/tests/testthat/test-figures.R
@@ -13,7 +13,7 @@ test_that("figures", {
   expect_match(txt, "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 1. A ggplot.</figcaption>\n</figure>\n")
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
-    sort(c("plots/x.csv", "plots/x.png"))
+    sort(c("plots/x.csv", "plots/x.png", "plots/x.yaml"))
   )
 
   skip("opens window")
@@ -116,13 +116,13 @@ test_that("figures pre_num", {
   expect_match(txt, "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 1. A ggplot.</figcaption>\n</figure>\n")
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
-    sort(c("plots/x.csv", "plots/x.png"))
+    sort(c("plots/x.csv", "plots/x.png", "plots/x.yaml"))
   )
   txt <- sbr_figures()
   expect_match(txt, "\n<figure>\n<img alt = \".*report/plots/x.png\" width = \"100%\">\n<figcaption>Figure 2. A ggplot.</figcaption>\n</figure>\n")
   expect_identical(
     sort(list.files(sbr_get_report(), recursive = TRUE)),
-    sort(c("plots/x.csv", "plots/x.png"))
+    sort(c("plots/x.csv", "plots/x.png", "plots/x.yaml"))
   )
 })
 
@@ -163,4 +163,26 @@ test_that("sbr_figures() lists the correct file names in the md string.", {
   file.remove(list.files("report", pattern = "plot-", recursive = TRUE, full.names = TRUE))
   file.remove(list.files("report", pattern = "\\.DS_Store", recursive = TRUE,
                          full.names = TRUE))
+})
+
+test_that("figures copies yaml and xlsx to report folder", {
+  path <- withr::local_tempdir()
+  subfoldr2::sbf_set_main(path, "output", rm = TRUE, ask = FALSE)
+  sbr_set_report(path, "report", rm = TRUE, ask = FALSE)
+  sbf_reset_sub()
+
+  data <- data.frame(x = 1:2, y = 3:4)
+  x <- ggplot2::ggplot(data = data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_point()
+  subfoldr2::sbf_save_plot(x, caption = "A ggplot")
+
+  main <- subfoldr2::sbf_get_main()
+  expect_true(file.exists(file.path(main, "plots/x.yaml")))
+  expect_true(file.exists(file.path(main, "plots/x.xlsx")))
+
+  sbr_figures()
+  report <- sbr_get_report()
+  expect_true(file.exists(file.path(report, "plots/x.png")))
+  expect_true(file.exists(file.path(report, "plots/x.yaml")))
+  expect_true(file.exists(file.path(report, "plots/x.xlsx")))
 })

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -9,13 +9,16 @@ test_that("tables", {
 
   txt <- sbr_tables()
   expect_identical(txt, "\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/x.csv")
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    c("tables/x.csv", "tables/x.yaml")
+  )
 
   subfoldr2::sbf_save_table(x, x_name = "y", report = FALSE)
   expect_identical(sbr_tables(), txt)
   expect_identical(
     list.files(sbr_get_report(), recursive = TRUE),
-    "tables/x.csv", "tables/y.csv"
+    c("tables/x.csv", "tables/x.yaml")
   )
 
   x_csv <- utils::read.csv(file.path(sbr_get_report(), "tables/x.csv"))
@@ -78,7 +81,10 @@ test_that("tables sub", {
 
   txt <- sbr_tables()
   expect_identical(txt, "\n#### A Sub\n\nTable 1. Observations.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/A sub/x.csv")
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    c("tables/A sub/x.csv", "tables/A sub/x.yaml")
+  )
 })
 
 test_that("tables missing caption", {
@@ -92,7 +98,10 @@ test_that("tables missing caption", {
 
   txt <- sbr_tables()
   expect_identical(txt, "\nTable 1.\n\n|obs | count|\n|:---|-----:|\n|JD  |     1|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/x.csv")
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    c("tables/x.csv", "tables/x.yaml")
+  )
 })
 
 test_that("tables sort sub and name", {
@@ -110,7 +119,7 @@ test_that("tables sort sub and name", {
   expect_identical(txt, "\nTable 1.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n\n#### B\n\nTable 2.\n\n|obs |count |\n|:---|:-----|\n|JD  |A     |\n")
   expect_identical(
     list.files(sbr_get_report(), recursive = TRUE),
-    c("tables/a.csv", "tables/b/a.csv")
+    c("tables/a.csv", "tables/a.yaml", "tables/b/a.csv", "tables/b/a.yaml")
   )
 
   txt <- sbr_tables(sort = c("b", "a"))
@@ -128,5 +137,30 @@ test_that("tables with []", {
 
   txt <- sbr_tables()
   expect_identical(txt, "\nTable 1.\n\n|term   | count|\n|:------|-----:|\n|par[1] |     1|\n|par[2] |     2|\n")
-  expect_identical(list.files(sbr_get_report(), recursive = TRUE), "tables/x.csv")
+  expect_identical(
+    list.files(sbr_get_report(), recursive = TRUE),
+    c("tables/x.csv", "tables/x.yaml")
+  )
+})
+
+test_that("tables copies yaml metadata to report folder", {
+  path <- withr::local_tempdir()
+  subfoldr2::sbf_set_main(path, "output", rm = TRUE, ask = FALSE)
+  sbr_set_report(path, "report", rm = TRUE, ask = FALSE)
+  sbf_reset_sub()
+
+  x <- data.frame(obs = "JD", count = 1L)
+  subfoldr2::sbf_save_table(x, caption = "Observations")
+  subfoldr2::sbf_save_table(x, x_name = "y", sub = "A sub", caption = "More")
+
+  expect_true(file.exists(file.path(subfoldr2::sbf_get_main(), "tables/x.yaml")))
+
+  sbr_tables()
+  expect_identical(
+    sort(list.files(sbr_get_report(), recursive = TRUE)),
+    sort(c(
+      "tables/x.csv", "tables/x.yaml",
+      "tables/A sub/y.csv", "tables/A sub/y.yaml"
+    ))
+  )
 })


### PR DESCRIPTION
Relates to poissonconsulting/poisreport#78.

## Summary
`sbr_tables()` and `sbr_figures()` build the report folder that `poisreport::report_to_directory()` and `poisreport::report_to_client()` copy to the project directory, but they only transferred the `.png` and `.csv` files, leaving the `.yaml` metadata and plot `.xlsx` files behind in the main output folder. `sbr_tables()` now transfers each table's `.yaml` from the main folder alongside the csv it writes. `sbr_figures()` now transfers each plot's `.yaml` and `.xlsx` alongside the existing png/csv transfers, and each window's `.yaml` alongside its png. Files absent from the main folder (e.g. a plot saved without xlsx data) are skipped silently, matching the existing csv transfer behaviour.

## Verification
```r
library(subreport)
path <- tempfile()
dir.create(path)
subfoldr2::sbf_set_main(path, "output", rm = TRUE, ask = FALSE)
sbr_set_report(path, "report", rm = TRUE, ask = FALSE)

data <- data.frame(x = 1:2, y = 3:4)
p <- ggplot2::ggplot(data, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()
subfoldr2::sbf_save_plot(p, caption = "A plot")
subfoldr2::sbf_save_table(data, caption = "A table")

sbr_figures()
sbr_tables()

list.files(sbr_get_report(), recursive = TRUE)
#> "plots/p.csv"  "plots/p.png"  "plots/p.xlsx"  "plots/p.yaml"  "tables/data.csv"  "tables/data.yaml"
```

Note: R-CMD-check is expected to show the same 3 pre-existing `test-figures.R` failures as `main` (#46); this PR does not change that baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)