### PR TITLE
Fix fledge reusable workflow references

### DIFF
--- a/.github/workflows/fledge-bump.yml
+++ b/.github/workflows/fledge-bump.yml
@@ -1,12 +1,19 @@
-  name: fledge-bump
-  on:
-    schedule:
-      - cron: "0 7 * * *"
-    workflow_dispatch:
-  permissions:
-    contents: write
-    pull-requests: write
-  jobs:
-    fledge-bump:
-      uses: poissonconsulting/.github/.github/workflows/fledge-bump.yml@f-fledge-automation@v1
-      secrets: inherit
+# Daily fledge dev-version bump. Calls the reusable engine in poissonconsulting/.github.
+# Requires the org-level secrets FLEDGE_APP_ID and FLEDGE_APP_PRIVATE_KEY (passed via
+# `secrets: inherit`) and the companion fledge-tag-on-merge.yml workflow in this repo.
+
+name: fledge-bump
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fledge-bump:
+    uses: poissonconsulting/.github/.github/workflows/fledge-bump.yml@v1
+    secrets: inherit

--- a/.github/workflows/fledge-tag-on-merge.yml
+++ b/.github/workflows/fledge-tag-on-merge.yml
@@ -1,12 +1,18 @@
-  name: fledge-tag-on-merge
-  on:
-    pull_request:
-      types: [closed]
-      branches: [main, master]
-  permissions:
-    contents: write
-  jobs:
-    tag:
-      if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'fledge-bump'
-      uses: poissonconsulting/.github/.github/workflows/fledge-tag-on-merge.yml@f-fledge-automation@v1
-      secrets: inherit
+# Tags the dev version on main after a release-path fledge-bump PR merges.
+# Required alongside fledge-bump.yml. Calls the reusable engine in poissonconsulting/.github.
+
+name: fledge-tag-on-merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'fledge-bump'
+    uses: poissonconsulting/.github/.github/workflows/fledge-tag-on-merge.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary
`fledge-bump.yml` and `fledge-tag-on-merge.yml` referenced the reusable workflows in `poissonconsulting/.github` at `@f-fledge-automation@v1`, a ref that does not exist (only tag `v1` does). GitHub therefore treated both workflow files as invalid, logging an instant failure on every push, and neither the daily dev-version bump nor the tag-on-merge ran (e.g. #48 merged without a version bump). Both files are replaced with the working versions from poisreport: reference `@v1` and standard indentation, with the explanatory header comments.

## Verification
Both files parse as valid YAML and reference `poissonconsulting/.github/.github/workflows/<name>.yml@v1`, which matches poisreport where the workflows run cleanly. After merging, the push-triggered instant failures should stop, and the next scheduled run (07:00 UTC daily) or a manual `workflow_dispatch` of fledge-bump should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)